### PR TITLE
forEach function is not recognized

### DIFF
--- a/src/app/shared/search/mocks/helper.ts
+++ b/src/app/shared/search/mocks/helper.ts
@@ -19,8 +19,11 @@ export class SpyObject {
       object = new SpyObject();
     }
 
-    let m = StringMapWrapper.merge(config, overrides);
-    StringMapWrapper.forEach(m, (value, key) => { object.spy(key).andReturn(value); });
+    let m = StringMapWrapper.merge(config, overrides);    
+    for (let key in m) {
+      object.spy(key).andReturn(m[key]);
+    }
+
     return object;
   }
 


### PR DESCRIPTION
The forEach function is not recognized in the StringMapWrapper. Using:
node 6.8.0
Jasmine 2.4.1
angular-cli 1.0.0-beta.17
